### PR TITLE
Fix character drop bug in
  stream_getnext_fasta for multi-line FASTA sequences

### DIFF
--- a/misc/tests/fasta_reader.h
+++ b/misc/tests/fasta_reader.h
@@ -52,6 +52,8 @@ static int stream_getnext_fasta(stream *S) {
                 S->pos--;
                 return 0;
             }
+            if (next != EOF)
+                S->pos--;
             continue;
         }
         if (c == '>') {

--- a/misc/tests/test.cpp
+++ b/misc/tests/test.cpp
@@ -119,11 +119,74 @@ void test_canonical_hash_values(){
     printf("[TEST] canonical_hash_values: PASSED (found %zu syncmers)\n", count);
 }
 
+static void test_fasta_reader_multiline() {
+    // single-line sequence
+    {
+        const char *data = ">seq1\nACGT\n";
+        FILE *f = fmemopen((void*)data, strlen(data), "r");
+        stream *S = stream_open_fasta(f);
+        char *seq = read_sequence(S);
+        assert(strcmp(seq, "acgt") == 0);
+        free(seq); stream_close(S); fclose(f);
+    }
+    // multi-line: first char of each non-first line was silently dropped before fix
+    {
+        const char *data = ">seq1\nACGT\nGGCC\n";
+        FILE *f = fmemopen((void*)data, strlen(data), "r");
+        stream *S = stream_open_fasta(f);
+        char *seq = read_sequence(S);
+        assert(strcmp(seq, "acgtggcc") == 0);
+        free(seq); stream_close(S); fclose(f);
+    }
+    // three-line sequence
+    {
+        const char *data = ">seq1\nAAAA\nCCCC\nGGGG\n";
+        FILE *f = fmemopen((void*)data, strlen(data), "r");
+        stream *S = stream_open_fasta(f);
+        char *seq = read_sequence(S);
+        assert(strcmp(seq, "aaaaccccgggg") == 0);
+        free(seq); stream_close(S); fclose(f);
+    }
+    // two sequences: read_sequence stops at '>' boundary
+    {
+        const char *data = ">s1\nACGT\n>s2\nGGCC\n";
+        FILE *f = fmemopen((void*)data, strlen(data), "r");
+        stream *S = stream_open_fasta(f);
+        char *seq1 = read_sequence(S);
+        assert(strcmp(seq1, "acgt") == 0);
+        char *seq2 = read_sequence(S);
+        assert(strcmp(seq2, "ggcc") == 0);
+        free(seq1); free(seq2); stream_close(S); fclose(f);
+    }
+    // two multi-line sequences (tests both boundary detection and char preservation)
+    {
+        const char *data = ">s1\nACGT\nNNNN\n>s2\nGGCC\nTTAA\n";
+        FILE *f = fmemopen((void*)data, strlen(data), "r");
+        stream *S = stream_open_fasta(f);
+        char *seq1 = read_sequence(S);
+        assert(strcmp(seq1, "acgtnnnn") == 0);
+        char *seq2 = read_sequence(S);
+        assert(strcmp(seq2, "ggccttaa") == 0);
+        free(seq1); free(seq2); stream_close(S); fclose(f);
+    }
+    // blank line within sequence is skipped
+    {
+        const char *data = ">seq\nACGT\n\nGGCC\n";
+        FILE *f = fmemopen((void*)data, strlen(data), "r");
+        stream *S = stream_open_fasta(f);
+        char *seq = read_sequence(S);
+        assert(strcmp(seq, "acgtggcc") == 0);
+        free(seq); stream_close(S); fclose(f);
+    }
+    printf("[TEST] fasta_reader_multiline: PASSED\n");
+}
+
 void run_unit_tests(){
     printf("=== RUNNING UNIT TESTS ===\n");
     test_base_to_bits();
     test_canonical_iterator_strand_independence();
     test_canonical_hash_values();
+    test_fasta_reader_multiline();
     printf("=== ALL UNIT TESTS PASSED ===\n\n");
 }
 

--- a/misc/tests/test.cpp
+++ b/misc/tests/test.cpp
@@ -129,7 +129,7 @@ static void test_fasta_reader_multiline() {
         assert(strcmp(seq, "acgt") == 0);
         free(seq); stream_close(S); fclose(f);
     }
-    // multi-line: first char of each non-first line was silently dropped before fix
+    // multi-line sequence
     {
         const char *data = ">seq1\nACGT\nGGCC\n";
         FILE *f = fmemopen((void*)data, strlen(data), "r");
@@ -147,7 +147,7 @@ static void test_fasta_reader_multiline() {
         assert(strcmp(seq, "aaaaccccgggg") == 0);
         free(seq); stream_close(S); fclose(f);
     }
-    // two sequences: read_sequence stops at '>' boundary
+    // two sequences
     {
         const char *data = ">s1\nACGT\n>s2\nGGCC\n";
         FILE *f = fmemopen((void*)data, strlen(data), "r");
@@ -158,7 +158,7 @@ static void test_fasta_reader_multiline() {
         assert(strcmp(seq2, "ggcc") == 0);
         free(seq1); free(seq2); stream_close(S); fclose(f);
     }
-    // two multi-line sequences (tests both boundary detection and char preservation)
+    // two multi-line sequences
     {
         const char *data = ">s1\nACGT\nNNNN\n>s2\nGGCC\nTTAA\n";
         FILE *f = fmemopen((void*)data, strlen(data), "r");
@@ -169,7 +169,7 @@ static void test_fasta_reader_multiline() {
         assert(strcmp(seq2, "ggccttaa") == 0);
         free(seq1); free(seq2); stream_close(S); fclose(f);
     }
-    // blank line within sequence is skipped
+    // blank line within sequence
     {
         const char *data = ">seq\nACGT\n\nGGCC\n";
         FILE *f = fmemopen((void*)data, strlen(data), "r");


### PR DESCRIPTION
## Summary

  - `stream_getnext_fasta` peeked ahead after `\n` to detect `>`, but discarded the peeked character when it was not `>`,
  silently dropping the first base of every subsequent line in multi-line sequences
  - Fix: decrement `S->pos` to put the peeked character back when it is not `>` or EOF
  - Adds regression tests in `test.cpp` covering single-line, multi-line, two-sequence, and blank-line-within-sequence cases